### PR TITLE
Remove unnecessary action input

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -23,7 +23,5 @@ jobs:
         run: npm run build
       - name: Update the release with the built Action and standardize tags
         uses: JasonEtco/build-and-tag-action@v2
-        with:
-          setup: ''
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
With the release of `JasonEtco/build-and-tag-action@v2`, the `setup` input is no longer needed or used. Removing it makes things better 😀 